### PR TITLE
Add krakend flavours

### DIFF
--- a/Dockerfile_krakend_gin
+++ b/Dockerfile_krakend_gin
@@ -1,0 +1,8 @@
+FROM golang:1.8
+
+RUN mkdir -p /etc/krakend
+
+RUN go get -v github.com/devopsfaith/krakend/examples/gin
+RUN go install github.com/devopsfaith/krakend/examples/gin
+
+CMD [ "gin", "-d", "-p", "8080", "-c", "/etc/krakend/krakend.json" ]

--- a/Dockerfile_krakend_gorilla
+++ b/Dockerfile_krakend_gorilla
@@ -1,0 +1,8 @@
+FROM golang:1.8
+
+RUN mkdir -p /etc/krakend
+
+RUN go get -v github.com/devopsfaith/krakend/examples/gorilla
+RUN go install github.com/devopsfaith/krakend/examples/gorilla
+
+CMD [ "gorilla", "-d", "-p", "8080", "-c", "/etc/krakend/krakend.json" ]

--- a/Dockerfile_krakend_mux
+++ b/Dockerfile_krakend_mux
@@ -1,0 +1,8 @@
+FROM golang:1.8
+
+RUN mkdir -p /etc/krakend
+
+RUN go get -v github.com/devopsfaith/krakend/examples/mux
+RUN go install github.com/devopsfaith/krakend/examples/mux
+
+CMD [ "mux", "-d", "-p", "8080", "-c", "/etc/krakend/krakend.json" ]

--- a/Dockerfile_krakend_negroni
+++ b/Dockerfile_krakend_negroni
@@ -1,0 +1,8 @@
+FROM golang:1.8
+
+RUN mkdir -p /etc/krakend
+
+RUN go get -v github.com/devopsfaith/krakend/examples/negroni
+RUN go install github.com/devopsfaith/krakend/examples/negroni
+
+CMD [ "negroni", "-d", "-p", "8080", "-c", "/etc/krakend/krakend.json" ]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+KrakenD Playground
+====
+
 The KrakenD Playground is a demo project that sets a KrakenD API using several
 endpoints from a static API.
 
@@ -7,28 +10,56 @@ folder.
 The KrakenD configuration is stored under `krakend/krakend.json` and you can
 drag this file anytime to the [KrakenD designer](http://www.krakend.io/designer/) and resume the edition from there.
 
-This demos uses the KrakenD free version, and is limited to 1000rps and 2 backend endpoints per KrakenD endpoint (if you add more they are ignored)
-
-Start
-===
+## Start
 
     docker-compose up
 
-Use
-===
+## Use
+
 - The KrakenD API runs in the port 8080
 - The static API runs in the port 8000
 
 E.g: [http://localhost:8080/splash]()
 
-Edit endpoints
-==============
+## Edit endpoints
+
 The KrakenD configuration is stored under `krakend/krakend.json` and you can
 drag this file anytime to the [KrakenD designer](http://www.krakend.io/designer/)
 
 The backend API endpoints are just static files in the `data` folder. Add or remove there.
 
+## Available demos
 
-Add your demos!
-===============
+### KrakenD Free
+
+This demo uses the [KrakenD free version](https://hub.docker.com/r/devopsfaith/krakend/), and is limited to 1000rps and 2 backend endpoints per KrakenD endpoint (if you add more they are ignored)
+
+	$ curl -i http://${DOCKER_IP}:8080/splash
+
+### OS KrakenD Gin
+
+This demo uses the [Gin example](https://github.com/devopsfaith/krakend/blob/master/examples/gin/main.go) from the KrakenD OS
+
+	$ curl -i http://${DOCKER_IP}:8081/splash
+
+### OS KrakenD Mux
+
+This demo uses the [Mux example](https://github.com/devopsfaith/krakend/blob/master/examples/mux/main.go) from the KrakenD OS
+
+	$ curl -i http://${DOCKER_IP}:8082/splash
+
+### OS KrakenD Gorilla
+
+This demo uses the [Gorilla example](https://github.com/devopsfaith/krakend/blob/master/examples/gorilla/main.go) from the KrakenD OS
+
+	$ curl -i http://${DOCKER_IP}:8083/splash
+
+### OS KrakenD Negroni
+
+This demo uses the [Negroni example](https://github.com/devopsfaith/krakend/blob/master/examples/negroni/main.go) from the KrakenD OS
+
+	$ curl -i http://${DOCKER_IP}:8084/splash
+
+## Add your demos!
+
 Please add your own examples by doing a pull request!

--- a/README.md
+++ b/README.md
@@ -40,25 +40,25 @@ This demo uses the [KrakenD free version](https://hub.docker.com/r/devopsfaith/k
 
 This demo uses the [Gin example](https://github.com/devopsfaith/krakend/blob/master/examples/gin/main.go) from the KrakenD OS
 
-	$ curl -i http://${DOCKER_IP}:8081/splash
+	$ curl -i -H'Host: ssl.example.com' http://${DOCKER_IP}:8081/splash
 
 ### OS KrakenD Mux
 
 This demo uses the [Mux example](https://github.com/devopsfaith/krakend/blob/master/examples/mux/main.go) from the KrakenD OS
 
-	$ curl -i http://${DOCKER_IP}:8082/splash
+	$ curl -i -H'Host: ssl.example.com' http://${DOCKER_IP}:8082/splash
 
 ### OS KrakenD Gorilla
 
 This demo uses the [Gorilla example](https://github.com/devopsfaith/krakend/blob/master/examples/gorilla/main.go) from the KrakenD OS
 
-	$ curl -i http://${DOCKER_IP}:8083/splash
+	$ curl -i -H'Host: ssl.example.com' http://${DOCKER_IP}:8083/splash
 
 ### OS KrakenD Negroni
 
 This demo uses the [Negroni example](https://github.com/devopsfaith/krakend/blob/master/examples/negroni/main.go) from the KrakenD OS
 
-	$ curl -i http://${DOCKER_IP}:8084/splash
+	$ curl -i -H'Host: ssl.example.com' http://${DOCKER_IP}:8084/splash
 
 ## Add your demos!
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ drag this file anytime to the [KrakenD designer](http://www.krakend.io/designer/
 
 ## Use
 
-- The KrakenD API runs in the port 8080
+- The KrakenD Free API runs in the port 8080
+- The KrakenD Gin API runs in the port 8081
+- The KrakenD Mux API runs in the port 8082
+- The KrakenD Gorilla API runs in the port 8083
+- The KrakenD Negroni API runs in the port 8084
 - The static API runs in the port 8000
 
 E.g: [http://localhost:8080/splash]()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,51 @@ services:
       - ./data:/lwan/wwwroot
     ports:
       - "8000:8080"
-  krakend:
+  krakend_free:
     image: devopsfaith/krakend
     volumes:
       - ./krakend:/etc/krakend
     ports:
       - "8080:8080"
+    links:
+      - fake_api
+  krakend_gin:
+    build:
+      context: ./
+      dockerfile: Dockerfile_krakend_gin
+    volumes:
+      - ./krakend:/etc/krakend
+    ports:
+      - "8081:8080"
+    links:
+      - fake_api
+  krakend_mux:
+    build:
+      context: ./
+      dockerfile: Dockerfile_krakend_mux
+    volumes:
+      - ./krakend:/etc/krakend
+    ports:
+      - "8082:8080"
+    links:
+      - fake_api
+  krakend_gorilla:
+    build:
+      context: ./
+      dockerfile: Dockerfile_krakend_gorilla
+    volumes:
+      - ./krakend:/etc/krakend
+    ports:
+      - "8083:8080"
+    links:
+      - fake_api
+  krakend_negroni:
+    build:
+      context: ./
+      dockerfile: Dockerfile_krakend_negroni
+    volumes:
+      - ./krakend:/etc/krakend
+    ports:
+      - "8084:8080"
     links:
       - fake_api


### PR DESCRIPTION
Add the available KrakenD examples to the playground.

This PR doesn't include the `dns` example because its external dependencies (a DNS-based service discovery layer)