### PR TITLE
update golang image to

### DIFF
--- a/Dockerfile_krakend_gin
+++ b/Dockerfile_krakend_gin
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.9
 
 RUN mkdir -p /etc/krakend
 

--- a/Dockerfile_krakend_gorilla
+++ b/Dockerfile_krakend_gorilla
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.9
 
 RUN mkdir -p /etc/krakend
 

--- a/Dockerfile_krakend_jwt
+++ b/Dockerfile_krakend_jwt
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.9
 
 RUN mkdir -p /etc/krakend
 

--- a/Dockerfile_krakend_mux
+++ b/Dockerfile_krakend_mux
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.9
 
 RUN mkdir -p /etc/krakend
 

--- a/Dockerfile_krakend_negroni
+++ b/Dockerfile_krakend_negroni
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.9
 
 RUN mkdir -p /etc/krakend
 


### PR DESCRIPTION
To avoid the error:
```
package math/bits: unrecognized import path "math/bits" (import path does not begin with hostname)
github.com/valyala/bytebufferpool (download)
Fetching https://gopkg.in/unrolled/secure.v1?go-get=1
Parsing meta tags from https://gopkg.in/unrolled/secure.v1?go-get=1 (status code 200)
get "gopkg.in/unrolled/secure.v1": found meta tag main.metaImport{Prefix:"gopkg.in/unrolled/secure.v1", VCS:"git", RepoRoot:"https://gopkg.in/unrolled/secure.v1"} at https://gopkg.in/unrolled/secure.v1?go-get=1
gopkg.in/unrolled/secure.v1 (download)
ERROR: Service 'krakend_mux' failed to build: The command '/bin/sh -c go get -v github.com/devopsfaith/krakend-examples/mux' returned a non-zero
```
upgrade to more cent version of goland