### PR TITLE
fix auth0 undefined issue

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -88,7 +88,7 @@
     </main>
   </div>
 
-  <script src="node_modules/auth0-js/build/auth0.js"></script>
+  <script src="node_modules/auth0-js/dist/auth0.js"></script>
   <script src="auth0-variables.js"></script>
   <script src="app.js"></script>
 </body>


### PR DESCRIPTION
**auth0** object was being shown undefined in app.js as it was looking for auth0.js in `node_modules/auth0/build` in web/index.js. ` node_modules/auth0/dist` fixes this. 